### PR TITLE
Fix broken design

### DIFF
--- a/lib/automaildoc/templates/toc.html.erb
+++ b/lib/automaildoc/templates/toc.html.erb
@@ -79,6 +79,17 @@
           width: 66%;
         }
       }
+      a.link-to-mail {
+        word-break: break-all;
+        white-space: pre;
+        white-space: pre-wrap;
+        white-space: pre-line;
+        white-space: -pre-wrap;
+        white-space: -o-pre-wrap;
+        white-space: -moz-pre-wrap;
+        white-space: -hp-pre-wrap;
+        word-wrap: break-word;
+      }
       hr {
         margin: 16px 0px
       }
@@ -92,7 +103,7 @@
           <ul>
             <% @mails.each do |mail| %>
               <li>
-                <a href="#<%= mail.id %>"><%= mail.description %></a>
+                <a class="link-to-mail" href="#<%= mail.id %>"><%= mail.description %></a>
               </li>
             <% end %>
           </ul>

--- a/spec/dummy/doc/toc.html
+++ b/spec/dummy/doc/toc.html
@@ -79,6 +79,17 @@
           width: 66%;
         }
       }
+      a.link-to-mail {
+        word-break: break-all;
+        white-space: pre;
+        white-space: pre-wrap;
+        white-space: pre-line;
+        white-space: -pre-wrap;
+        white-space: -o-pre-wrap;
+        white-space: -moz-pre-wrap;
+        white-space: -hp-pre-wrap;
+        word-wrap: break-word;
+      }
       hr {
         margin: 16px 0px
       }
@@ -92,11 +103,11 @@
           <ul>
             
               <li>
-                <a href="#./spec/mails/meetup_spec.rb[1:1]">Meetup mail should sent to user</a>
+                <a class="link-to-mail" href="#./spec/mails/meetup_spec.rb[1:1]">Meetup mail should sent to user</a>
               </li>
             
               <li>
-                <a href="#./spec/mails/signup_spec.rb[1:1]">Sign up mail for newly signed up user</a>
+                <a class="link-to-mail" href="#./spec/mails/signup_spec.rb[1:1]">Sign up mail for newly signed up user</a>
               </li>
             
           </ul>


### PR DESCRIPTION
TOC's link is broken when it's so long.

## Before

<img width="933" alt="2017-09-06 0 47 45" src="https://user-images.githubusercontent.com/1811616/30070084-58fce0a6-929d-11e7-8147-ce956431c728.png">

## After

<img width="952" alt="2017-09-06 0 47 27" src="https://user-images.githubusercontent.com/1811616/30070080-5692c4d4-929d-11e7-906b-0bfcc5ffa2c2.png">

